### PR TITLE
refs #4 rubocopを導入し、Lintを実行できるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 group :development, :test do
   gem 'rspec-rails', '~> 3.8'
 end
+
+group :development, :test do
+  gem 'rubocop', require: false
+end


### PR DESCRIPTION
```
rubocopを導入し、Lintを実行できるようにする
```
`rubocop --lint` を実行できるところまで実装

特にチェックルールの指定がなかったので `.rubocop.yml` は作成していません